### PR TITLE
refactor(config): Unified AI Model Dropdown Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,67 +49,42 @@
     "configuration": {
       "title": "Layr",
       "properties": {
-        "layr.aiProvider": {
-          "type": "string",
-          "enum": [
-            "gemini",
-            "openai",
-            "claude"
-          ],
-          "default": "gemini",
-          "description": "Select your AI provider",
-          "enumDescriptions": [
-            "Google Gemini AI (Fast & Free)",
-            "OpenAI GPT (Most Popular)",
-            "Anthropic Claude (Advanced Reasoning)"
-          ],
-          "scope": "application",
-          "order": 1
-        },
         "layr.apiKey": {
           "type": "string",
           "default": "",
           "description": "API Key for your selected AI provider",
           "scope": "application",
-          "order": 2
+          "order": 1
         },
-        "layr.geminiModel": {
+        "layr.aiModel": {
           "type": "string",
           "enum": [
             "gemini-2.5-flash",
             "gemini-2.5-pro",
             "gemini-1.5-pro",
             "gemini-1.5-flash",
-            "gemini-pro"
-          ],
-          "default": "gemini-2.5-flash",
-          "description": "Gemini model to use",
-          "scope": "application",
-          "order": 3
-        },
-        "layr.openaiModel": {
-          "type": "string",
-          "enum": [
+            "gemini-pro",
             "gpt-4",
             "gpt-4-turbo",
-            "gpt-3.5-turbo"
-          ],
-          "default": "gpt-4",
-          "description": "OpenAI model to use",
-          "scope": "application",
-          "order": 4
-        },
-        "layr.claudeModel": {
-          "type": "string",
-          "enum": [
+            "gpt-3.5-turbo",
+            "gpt-4o",
+            "gpt-5-medium",
+            "gpt-5-high",
             "claude-3-sonnet",
             "claude-3-opus",
-            "claude-3-haiku"
+            "claude-3-haiku",
+            "claude-3.7-sonnet",
+            "claude-4-sonnet",
+            "kimi-k2-0905",
+            "deepseek-v3.1",
+            "grok-4",
+            "o3"
           ],
-          "default": "claude-3-sonnet",
-          "description": "Claude model to use",
+          "default": "gemini-2.5-flash",
+          "order": 2,
+          "description": "AI model to use",
           "scope": "application",
-          "order": 5
+          "order": 3
         },
         "layr.openaiOrganization": {
           "type": "string",


### PR DESCRIPTION
# Unified AI Model Dropdown Implementation #3 

## Description
This PR implements a unified AI model dropdown that replaces the separate provider-specific model dropdowns. The implementation automatically determines the appropriate AI provider based on the selected model name.

## Changes Made
1. Removed `layr.aiProvider` setting from `package.json`
2. Updated the `Planner` class in `src/planner/index.ts` to:
   - Use a single `aiModel` property instead of separate model properties
   - Determine the AI provider based on model name prefixes
   - Simplify the configuration loading process
3. Updated `extension.ts` to:
   - Listen for changes to the unified `layr.aiModel` setting
   - Update the debug command to display information based on the unified model

## How to Test
1. Install the extension
2. Open VS Code settings and verify that:
   - Only one AI model dropdown is visible
   - The AI provider dropdown is no longer present
3. Select different models from the dropdown and verify that:
   - The appropriate API key is used
   - Plans are generated correctly


## Additional Notes
- This change maintains backward compatibility with existing configurations
- The extension automatically determines which provider to use based on the model name prefix:
  - Models starting with "gemini" use the Gemini provider
  - Models starting with "gpt" or "o3" use the OpenAI provider
  - Models starting with "claude" use the Claude provider
  - Other models (Kimi, DeepSeek, Grok) default to OpenAI provider